### PR TITLE
added support for changing rendering order

### DIFF
--- a/plugins/RenderProjectilesAboveActors/engine/engine.json
+++ b/plugins/RenderProjectilesAboveActors/engine/engine.json
@@ -1,1 +1,19 @@
-{"version": "4.0.2-e0"}
+{
+    
+"version": "4.0.2-e0",
+
+"fields": [
+    {
+      "key": "rendering_order",
+      "label": "Rendering Order",
+      "group": "Sprite Rendering Order",
+      "type": "select",
+      "options": [
+        [0, "Sprites on top"],
+        [1, "Projectiles on top"]
+      ],
+      "cType": "UBYTE",
+      "default": 0
+    }
+]
+}

--- a/plugins/RenderProjectilesAboveActors/engine/engine.json
+++ b/plugins/RenderProjectilesAboveActors/engine/engine.json
@@ -9,7 +9,7 @@
       "group": "Sprite Rendering Order",
       "type": "select",
       "options": [
-        [0, "Sprites on top"],
+        [0, "Actors on top"],
         [1, "Projectiles on top"]
       ],
       "cType": "UBYTE",

--- a/plugins/RenderProjectilesAboveActors/engine/engine.json
+++ b/plugins/RenderProjectilesAboveActors/engine/engine.json
@@ -13,7 +13,7 @@
         [1, "Projectiles on top"]
       ],
       "cType": "UBYTE",
-      "default": 0
+      "defaultValue":
     }
 ]
 }

--- a/plugins/RenderProjectilesAboveActors/engine/include/core.h
+++ b/plugins/RenderProjectilesAboveActors/engine/include/core.h
@@ -1,0 +1,11 @@
+#ifndef _CORE_H_INCLUDE
+#define _CORE_H_INCLUDE
+
+#include <gbdk/platform.h>
+
+void core_reset(void) BANKED;
+void core_run(void) BANKED;
+
+extern UBYTE rendering_order;
+
+#endif

--- a/plugins/RenderProjectilesAboveActors/engine/src/core/core.c
+++ b/plugins/RenderProjectilesAboveActors/engine/src/core/core.c
@@ -34,6 +34,8 @@
 #include "shadow.h"
 #include "data/data_bootstrap.h"
 
+UBYTE rendering_order;
+
 extern void __bank_bootstrap_script;
 extern const UBYTE bootstrap_script[];
 
@@ -80,8 +82,14 @@ void process_VM(void) {
 
                 camera_update();
                 scroll_update();
-                projectiles_update();                                   // update and render projectiles
-                actors_update();
+                if(rendering_order){                                    // if sprites on top
+                    projectiles_update();                               // render projectiles first
+                    actors_update();
+                } else {                                                // else if projectiles on top
+                    actors_update();                                    // reverse the rendering order
+                    projectiles_update();                                   
+                }
+                
 
                 ui_update();
                 actors_handle_player_collision();

--- a/plugins/RenderProjectilesAboveActors/engine/src/core/core.c
+++ b/plugins/RenderProjectilesAboveActors/engine/src/core/core.c
@@ -82,7 +82,7 @@ void process_VM(void) {
 
                 camera_update();
                 scroll_update();
-                if(rendering_order){                                    // if sprites on top
+                if(rendering_order){                                    // if actors on top
                     projectiles_update();                               // render projectiles first
                     actors_update();
                 } else {                                                // else if projectiles on top

--- a/plugins/RenderProjectilesAboveActors/events/eventSetRenderingOrder.js
+++ b/plugins/RenderProjectilesAboveActors/events/eventSetRenderingOrder.js
@@ -1,0 +1,36 @@
+const id = "FO_EVENT_SET_RENDERING_ORDER";
+const name = "Set Projectile Rendering Order";
+const groups = ["Projectiles"];
+
+
+const fields = [
+
+  {
+    key: "order",
+    label: "Set Hookshot State",
+    type: "select",
+    options: [
+        [0, "Sprites on top"],
+        [1, "Projectiles on top"]
+      ],
+    defaultValue: 0,
+  }
+
+];
+
+const compile = (input, helpers) => {
+  const { 
+    engineFieldSetToValue,
+  } = helpers;
+  
+  engineFieldSetToValue("rendering_order", input.order);
+
+};
+
+module.exports = {
+  id,
+  name,
+  groups,
+  fields,
+  compile,
+};

--- a/plugins/RenderProjectilesAboveActors/events/eventSetRenderingOrder.js
+++ b/plugins/RenderProjectilesAboveActors/events/eventSetRenderingOrder.js
@@ -7,10 +7,10 @@ const fields = [
 
   {
     key: "order",
-    label: "Set Hookshot State",
+    label: "Set Projectile Rendering Order",
     type: "select",
     options: [
-        [0, "Sprites on top"],
+        [0, "Actors on top"],
         [1, "Projectiles on top"]
       ],
     defaultValue: 0,


### PR DESCRIPTION
Added support to change rendering order based on the new engine field "rendering_order".
Also added an event called "Set Projectile Rendering Order", so that this field can be changed by the user whenever they want.